### PR TITLE
Correct blood altar calculation for large stacks

### DIFF
--- a/src/main/java/io/github/drmanganese/topaddons/addons/AddonBloodMagic.java
+++ b/src/main/java/io/github/drmanganese/topaddons/addons/AddonBloodMagic.java
@@ -116,7 +116,7 @@ public class AddonBloodMagic extends AddonBlank {
     }
 
     private void addAltarCraftingElement(IProbeInfo probeInfo, ItemStack input, ItemStack result, int progress, int required, float consumption) {
-        probeInfo.element(new ElementAltarCrafting(input, result, progress, required, consumption));
+        probeInfo.element(new ElementAltarCrafting(input, result, progress, required * input.stackSize, consumption));
     }
 
     @SuppressWarnings("ConstantConditions")


### PR DESCRIPTION
A minor fix, may need reworking to provide more information, but resolves the bug where mass crafting in the blood altar results in incorrect display.