### PR TITLE
Extended view on Storage Drawers no longer disables globally

### DIFF
--- a/src/main/java/io/github/drmanganese/topaddons/addons/AddonStorageDrawers.java
+++ b/src/main/java/io/github/drmanganese/topaddons/addons/AddonStorageDrawers.java
@@ -77,8 +77,13 @@ public class AddonStorageDrawers extends AddonBlank {
 
     @Override
     public void getProbeConfig(IProbeConfig config, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data) {
-        if (world.getTileEntity(data.getPos()) instanceof TileEntityDrawers && player.isSneaking()) {
-            config.showChestContents(IProbeConfig.ConfigMode.NOT);
+        if (world.getTileEntity(data.getPos()) instanceof TileEntityDrawers) {
+            if (player.isSneaking()) {
+                config.showChestContents(IProbeConfig.ConfigMode.NOT);
+            }
+            else {
+                config.showChestContents(IProbeConfig.ConfigMode.EXTENDED);
+            }
         }
     }
 }


### PR DESCRIPTION
While this is a bit of a hack, on a hack, it does mostly mask the issue.  This should not be considered as the correct approach to solving #21, but it will make it less noticeable.