### PR TITLE
[1.10.2] Added Support for AgriCraft

### DIFF
--- a/src/main/java/io/github/drmanganese/topaddons/TOPAddons.java
+++ b/src/main/java/io/github/drmanganese/topaddons/TOPAddons.java
@@ -45,7 +45,8 @@ import java.io.File;
                 "after:StorageDrawers;" +
                 "after:Botania;" +
                 "after:IC2;" +
-                "after:neotech;",
+                "after:neotech;" +
+                "after:agricraft;",
         updateJSON = "https://raw.githubusercontent.com/DrManganese/TOPAddons/master/FUC.json"
 )
 public class TOPAddons {

--- a/src/main/java/io/github/drmanganese/topaddons/addons/AddonAgriCraft.java
+++ b/src/main/java/io/github/drmanganese/topaddons/addons/AddonAgriCraft.java
@@ -1,0 +1,77 @@
+package io.github.drmanganese.topaddons.addons;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.World;
+
+import com.infinityraider.agricraft.api.misc.IAgriDisplayable;
+import com.infinityraider.agricraft.tiles.TileEntityCrop;
+import io.github.drmanganese.topaddons.api.TOPAddon;
+import io.github.drmanganese.topaddons.config.Config;
+import mcjty.theoneprobe.api.IProbeHitData;
+import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.ProbeMode;
+
+
+@TOPAddon(dependency = "agricraft")
+public class AddonAgriCraft extends AddonBlank {
+
+	@Override
+	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data) {
+
+		TileEntity tileEntity = world.getTileEntity(data.getPos());
+		if(tileEntity instanceof TileEntityCrop) {
+
+			List<String> info = new ArrayList<>();
+			List<String> revisedInfo;
+			((IAgriDisplayable) tileEntity).addDisplayInfo(info);
+
+			revisedInfo = getModeAppropriateData(info, mode);
+
+			for(String line:revisedInfo) {
+				probeInfo.text(line);
+			}
+
+		}
+	}
+
+	private List<String> getModeAppropriateData(List<String> info, ProbeMode mode) {
+		List<String> revisedList = new ArrayList<>();
+		//Two strings indicates an empty crop
+		if(info.size() == 2) {
+			revisedList.add(formatText(info.get(0)));
+			revisedList.add(formatText(info.get(1)));
+		}
+
+		//Five strings indicates an unanalyzed crop
+		if(info.size() == 5)
+			for(int i = 0;i<info.size();i++) {
+				if (i == 3 && mode == ProbeMode.NORMAL && Config.AgriCraft.extendedMode) continue;
+				revisedList.add(formatText(info.get(i)));
+			}
+		//Seven strings indicates an analayzed crop
+		if(info.size() == 7) {
+			for(int i = 0; i<info.size();i++) {
+				if((i == 3 || i == 4 || i == 5) && mode == ProbeMode.NORMAL && Config.AgriCraft.extendedMode) continue;
+				revisedList.add(formatText(info.get(i)));
+			}
+		}
+		return revisedList;
+	}
+
+	private String formatText(String line) {
+		String[] text = line.split(":");
+		if(text.length == 2) {
+			return (TextFormatting.GREEN + text[0] + ":" + TextFormatting.RESET + text[1]);
+		} else {
+			return line;
+		}
+	}
+
+}
+

--- a/src/main/java/io/github/drmanganese/topaddons/config/Config.java
+++ b/src/main/java/io/github/drmanganese/topaddons/config/Config.java
@@ -13,6 +13,11 @@ import java.util.Set;
 
 public class Config {
 
+    public static class AgriCraft {
+        public static boolean extendedMode = true;
+        static final String CATEGORY = "AgriCraft";
+    }
+
     public static class BloodMagic {
         public static boolean requireSigil = true;
         static final String CATEGORY = "Blood Magic";
@@ -39,6 +44,7 @@ public class Config {
     public static void init(Configuration config) {
         config.load();
 
+        AgriCraft.extendedMode = config.getBoolean("extendedMode", AgriCraft.CATEGORY, true, "Require a Probe to see growth stages");
         BloodMagic.requireSigil = config.getBoolean("requireSigil", BloodMagic.CATEGORY, true, "Is holding a divination sigil required to see certain information.");
         Forge.showTankGauge = config.getBoolean("showTankGauge", Forge.CATEGORY, true, "Show tank gauge for internal tanks on most Tile Entities.");
         Vanilla.noteBlock = config.getBoolean("noteBlockPitch", Vanilla.CATEGORY, true, "Show note block pitch and instrument.");


### PR DESCRIPTION
I'm not sure if you're still maintaining this for 1.10.2, but if you are, I think that AgriCraft support could be very useful. 

This taps into AgriCraft's IAgriDisplayable which was designed for WAILA. I only adjust the highlighting of the text. By default a Probe is required to see crop stats, that behavior can be disabled however.