### PR TITLE
Fix locked+empty drawers losing their item reservations

### DIFF
--- a/src/main/java/io/github/drmanganese/topaddons/addons/AddonStorageDrawers.java
+++ b/src/main/java/io/github/drmanganese/topaddons/addons/AddonStorageDrawers.java
@@ -35,7 +35,7 @@ public class AddonStorageDrawers extends AddonBlank {
             if (mode == ProbeMode.EXTENDED) {
                 NonNullList<ItemStack> stacks = NonNullList.create();
                 for (int i = 0; i < tile.getGroup().getDrawerCount(); i++) {
-                    ItemStack stack = tile.getGroup().getDrawer(i).getStoredItemPrototype();
+                    ItemStack stack = tile.getGroup().getDrawer(i).getStoredItemPrototype().copy();
                     if (!stack.isEmpty()) {
                         stack.setCount(tile.getGroup().getDrawer(i).getStoredItemCount());
                         stacks.add(stack);


### PR DESCRIPTION
Changing the stack size of the item prototype to zero causes it to become empty, making the drawer think it is no longer locked to an item. Instead of changing the size of a stack owned by the drawer, make a copy.

Furthermore, the ItemStack returned by `getStoredItemPrototype()` [*should not be modified for any reason.*](https://github.com/jaquadro/StorageDrawers/blob/1.12/src/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java#L10-L15)

This was a pain to debug.