### PR TITLE
Thermal: Updated dependencies to 1.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,9 +79,9 @@ dependencies {
     compile fg.deobf("curse.maven:industrial-foregoing-266515:3223241")
     compile fg.deobf("curse.maven:titanium-287342:3223141")
 
-    compile fg.deobf("curse.maven:cofh-core-69162:3155824")
-    compile fg.deobf("curse.maven:thermal-foundation-222880:3155830")
-    compile fg.deobf("curse.maven:thermal-expansion-69163:3155832")
+    compile fg.deobf("curse.maven:cofh-core-69162:3247581")
+    compile fg.deobf("curse.maven:thermal-foundation-222880:3248150")
+    compile fg.deobf("curse.maven:thermal-expansion-69163:3247000")
 
     compile fg.deobf("curse.maven:blood-magic-224791:3184485")
 

--- a/src/main/java/io/github/drmanganese/topaddons/addons/thermal/ThermalExpansionAddon.java
+++ b/src/main/java/io/github/drmanganese/topaddons/addons/thermal/ThermalExpansionAddon.java
@@ -13,9 +13,9 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.fml.config.ModConfig;
 
-import cofh.thermal.core.tileentity.DynamoTileBase;
-import cofh.thermal.core.tileentity.MachineTileProcess;
-import cofh.thermal.core.tileentity.ThermalTileBase;
+import cofh.thermal.lib.tileentity.DynamoTileBase;
+import cofh.thermal.lib.tileentity.MachineTileProcess;
+import cofh.thermal.lib.tileentity.ThermalTileBase;
 import cofh.thermal.core.tileentity.storage.EnergyCellTile;
 import com.google.common.collect.ImmutableMultimap;
 

--- a/src/main/java/io/github/drmanganese/topaddons/addons/thermal/tiles/DynamoTileInfo.java
+++ b/src/main/java/io/github/drmanganese/topaddons/addons/thermal/tiles/DynamoTileInfo.java
@@ -7,7 +7,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.world.World;
 
-import cofh.thermal.core.tileentity.DynamoTileBase;
+import cofh.thermal.lib.tileentity.DynamoTileBase;
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.ProbeMode;

--- a/src/main/java/io/github/drmanganese/topaddons/addons/thermal/tiles/MachineTileInfo.java
+++ b/src/main/java/io/github/drmanganese/topaddons/addons/thermal/tiles/MachineTileInfo.java
@@ -9,7 +9,7 @@ import net.minecraft.item.DyeColor;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.world.World;
 
-import cofh.thermal.core.tileentity.MachineTileProcess;
+import cofh.thermal.lib.tileentity.MachineTileProcess;
 import com.google.common.collect.ImmutableMap;
 import mcjty.theoneprobe.api.*;
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -36,3 +36,8 @@ description="The One Probe integration for various mods"
     modId="storagedrawers"
     mandatory=false
     ordering="AFTER"
+[[dependencies.topaddons]]
+    modId="cofh_core"
+    mandatory=false
+    versionRange="[1.2.0,)"
+    ordering="AFTER"


### PR DESCRIPTION
Breaks cofh packages so not backwards compatible