### PR TITLE
Fix ArithmeticException in FluidGaugeElement

### DIFF
--- a/src/main/java/io/github/drmanganese/topaddons/elements/forge/FluidGaugeElement.java
+++ b/src/main/java/io/github/drmanganese/topaddons/elements/forge/FluidGaugeElement.java
@@ -142,6 +142,8 @@ public class FluidGaugeElement implements IElement {
      * calculated with awt.Color.darker (0.7 * r/g/b).
      */
     private void renderFluid(MatrixStack matrixStack, int x, int y, int color) {
+        if (capacity == 0)
+            return;
         color = (color & 0x00ffffff) | (ForgeAddon.gaugeFluidColorTransparency.get()) << 24;
         final int darkerColor = new Color(color, true).darker().hashCode();
         for (int i = 0; i < Math.min(INNER_WIDTH * amount / capacity, INNER_WIDTH); i++) {
@@ -160,6 +162,8 @@ public class FluidGaugeElement implements IElement {
      * Render the fluid by tiling its texture. Eac
      */
     private void renderFluid(MatrixStack matrixStack, int x, int y, Fluid fluid) {
+        if (capacity == 0)
+            return;
         final Tessellator tessellator = Tessellator.getInstance();
         final BufferBuilder buffer = tessellator.getBuffer();
         final TextureAtlasSprite texture = FluidColorExtraction.getStillFluidTextureSafe(fluid);


### PR DESCRIPTION
Our player send us some weird CrashReport, I can't reproduce it.
```
java.lang.ArithmeticException: / by zero
	at io.github.drmanganese.topaddons.elements.forge.FluidGaugeElement.renderFluid(FluidGaugeElement.java:186) ~[topaddons:1.16.5-2.1.5-beta] {re:classloading}
	at io.github.drmanganese.topaddons.elements.forge.FluidGaugeElement.render(FluidGaugeElement.java:77) ~[topaddons:1.16.5-2.1.5-beta] {re:classloading}
	at mcjty.theoneprobe.apiimpl.elements.ElementVertical.render(ElementVertical.java:54) ~[theoneprobe:1.16-3.1.4] {re:classloading}
	at mcjty.theoneprobe.rendering.OverlayRenderer.renderElements(OverlayRenderer.java:433) ~[theoneprobe:1.16-3.1.4] {re:classloading}
	at mcjty.theoneprobe.rendering.OverlayRenderer.renderHUDBlock(OverlayRenderer.java:279) ~[theoneprobe:1.16-3.1.4] {re:classloading}
	at mcjty.theoneprobe.rendering.OverlayRenderer.renderHUD(OverlayRenderer.java:115) ~[theoneprobe:1.16-3.1.4] {re:classloading}
	at mcjty.theoneprobe.proxy.ClientProxy.renderGameOverlayEvent(ClientProxy.java:110) ~[theoneprobe:1.16-3.1.4] {re:classloading}
	at net.minecraftforge.eventbus.ASMEventHandler_2904_ClientProxy_renderGameOverlayEvent_Pre.invoke(.dynamic) ~[?:?] {}
	at net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:85) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:302) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:283) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.client.gui.ForgeIngameGui.renderHUDText(ForgeIngameGui.java:634) ~[forge:?] {re:classloading}
	at net.minecraftforge.client.gui.ForgeIngameGui.func_238445_a_(ForgeIngameGui.java:187) ~[forge:?] {re:classloading}
	at net.minecraft.client.renderer.GameRenderer.func_195458_a(GameRenderer.java:765) ~[?:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,xf:OptiFine:default,xf:fml:astralsorcery:reach_set_client_renderer,pl:mixin:APP:flywheel.mixins.json:StoreProjectionMatrixMixin,pl:mixin:APP:flickerfix.mixins.json:MixinGameRenderer,pl:mixin:A}
	at net.minecraft.client.Minecraft.func_195542_b(Minecraft.java:976) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,xf:fml:customskinloader:MinecraftTransformer,pl:mixin:APP:randompatches.mixins.json:client.MinecraftMixin,pl:mixin:APP:flywheel.mixins.json:ShaderCloseMixin,pl:mixin:APP:abnormals_core.mixins.json:client.MinecraftMixin,pl:mixin:APP:kubejs-common.mixins.json:MinecraftMixin,pl:mixin:APP:immersiveengineering.mixins.json:accessors.client.MinecraftAccess,pl:mixin:APP:assets/botania/botania.mixins.json:AccessorMinecraft,pl:mixin:APP:mixins.zycraft.json:client.MinecraftMixin,pl:mixin:APP:create.mixins.json:WindowResizeMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:607) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,xf:fml:customskinloader:MinecraftTransformer,pl:mixin:APP:randompatches.mixins.json:client.MinecraftMixin,pl:mixin:APP:flywheel.mixins.json:ShaderCloseMixin,pl:mixin:APP:abnormals_core.mixins.json:client.MinecraftMixin,pl:mixin:APP:kubejs-common.mixins.json:MinecraftMixin,pl:mixin:APP:immersiveengineering.mixins.json:accessors.client.MinecraftAccess,pl:mixin:APP:assets/botania/botania.mixins.json:AccessorMinecraft,pl:mixin:APP:mixins.zycraft.json:client.MinecraftMixin,pl:mixin:APP:create.mixins.json:WindowResizeMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.main.Main.main(Main.java:184) ~[All%20the%20Mods%206.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?] {}
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?] {}
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?] {}
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?] {}
	at net.minecraftforge.fml.loading.FMLClientLaunchProvider.lambda$launchService$0(FMLClientLaunchProvider.java:51) ~[forge-1.16.5-36.2.4.jar:36.2] {}
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:54) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:72) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:82) [modlauncher-8.0.9.jar:?] {re:classloading}
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:66) [modlauncher-8.0.9.jar:?] {re:classloading}
```

This patch may help, but just a temporary fix.